### PR TITLE
Downgrade dependencies

### DIFF
--- a/EssentialsPlus/EssentialsPlus.csproj
+++ b/EssentialsPlus/EssentialsPlus.csproj
@@ -5,8 +5,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
-    <PackageReference Include="MySql.Data" Version="9.3.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
+    <PackageReference Include="MySql.Data" Version="9.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="TShock" Version="6.0.0" />
     <PackageReference Include="TSAPI" Version="6.0.0" />


### PR DESCRIPTION
With the Microsoft.Data.Sqlite and MySql.Data dependencies, there were issues on plugin load with the version being different than what TShock uses.